### PR TITLE
build(nix): add flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple [Stremio](https://stremio.com) client for [GNOME](https://www.gnome.org
 
 </div>
 
-> [!NOTE]  
+> [!NOTE]
 > This is a work in progress, missing features and bugs to be expected.
 
 ## Installation
@@ -24,12 +24,43 @@ dnf install Losange
 
 ### Nix/NixOS
 
-Install using the `losange` package from [Nixpkgs](https://search.nixos.org/packages?query=losange).
+#### Nixpkgs (Recommended)
+
+You can install the latest stable release using the `losange` package from [Nixpkgs](https://search.nixos.org/packages?query=losange).
 
 You can also try out Losange without installing:
 
 ```bash
 nix run nixpkgs#losange
+```
+
+#### Flake
+
+You can install the latest development ("tip") version using the Flake from Losange's source repository.
+
+First, add the following to your Flake inputs:
+
+```nix
+{
+  inputs.losange.url = "github:tymmesyde/Losange";
+  inputs.losange.inputs.nixpkgs.follows = "nixpkgs";
+}
+```
+
+Then install the package using `inputs.losange.packages.${pkgs.stdenv.hostPlatform.system}.losange`.
+
+Alternatively, you can add the following overlay and then just install using `pkgs.losange`:
+
+```nix
+{
+  nixpkgs.overlays = [ inputs.losange.overlays.default ];
+}
+```
+
+You can also try out Losange without installing:
+
+```bash
+nix run github:tymmesyde/Losange
 ```
 
 ## Development
@@ -45,6 +76,18 @@ git clone --recurse-submodules https://github.com/tymmesyde/Losange
 dnf install gtk4-devel libadwaita-devel mpv-devel
 cargo install cargo-generate-rpm
 ```
+
+#### Nix
+
+The Nix build environment can be accessed like any other [Nix dev shell](https://nix.dev/tutorials/first-steps/declarative-shell.html), via the `nix develop` command (or `nix-shell` if you don't have the [nix-command experimental feature](https://nix.dev/manual/nix/2.24/development/experimental-features#xp-feature-nix-command) enabled).
+
+After setting up the Nix environment, you can run the same `cargo` commands as on other distributions or you can build the package with Nix by running:
+
+```bash
+nix build .#losange
+```
+
+The binary would then be located under `./result/bin/`.
 
 #### Ubuntu
 ```bash
@@ -70,6 +113,13 @@ cargo build --release
 strip -s target/release/losange
 cargo generate-rpm
 #> target/generate-rpm/*.rpm
+```
+
+#### Nix
+
+```bash
+# the binary will be located under ./result/bin/
+nix build .#losange
 ```
 
 #### Ubuntu

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "Losange: A simple Stremio client for GNOME";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      crane,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+
+      mkLosange =
+        pkgs:
+        pkgs.callPackage ./nix/package.nix {
+          revision = self.shortRev or self.dirtyShortRev or "dirty";
+          craneLib = crane.mkLib pkgs;
+        };
+    in
+    {
+      overlays.default = final: prev: {
+        losange = mkLosange prev;
+      };
+
+      packages = forAllSystems (pkgs: rec {
+        losange = mkLosange pkgs;
+        default = losange;
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.callPackage ./nix/devShell.nix {
+          losange = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-tree);
+    };
+}

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,0 +1,18 @@
+{
+  pkgs,
+  losange,
+}:
+pkgs.mkShell {
+  # Automatically inherit all the build dependencies (like mpv, libadwaita, pkg-config, etc.)
+  # from the main package derivation so we don't have to maintain the list twice.
+  inputsFrom = [ losange ];
+
+  packages = with pkgs; [
+    cargo
+    rustc
+    rustfmt
+    clippy
+    rust-analyzer
+    nixfmt
+  ];
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  craneLib,
+  revision,
+
+  # buildInputs (build deps)
+  mpv,
+  libadwaita,
+  libepoxy,
+  openssl,
+
+  # nativeBuildInputs (runtime deps)
+  makeBinaryWrapper,
+  pkg-config,
+  wrapGAppsHook4,
+  glib,
+
+  # Wrapper
+  nodejs,
+}:
+let
+  # rustPlatform.buildRustPackage rebuilds every crate in Cargo.lock on any source change.
+  # Splitting the build into crane's buildDepsOnly + buildPackage keeps the dependency
+  # crates in their own derivation that only rebuilds when Cargo.{toml,lock} change.
+  commonArgs = {
+    pname = "losange";
+    version = "${(builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version}-${revision}-nix";
+
+    src = lib.cleanSource ../.;
+
+    strictDeps = true;
+
+    buildInputs = [
+      mpv
+      libadwaita
+      libepoxy
+      openssl
+    ];
+
+    nativeBuildInputs = [
+      makeBinaryWrapper
+      pkg-config
+      wrapGAppsHook4
+      glib
+    ];
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+in
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+
+    postInstall = ''
+      install -Dm444 data/xyz.timtimtim.Losange.gschema.xml -t $out/share/gsettings-schemas/$name/glib-2.0/schemas/
+      glib-compile-schemas $out/share/gsettings-schemas/$name/glib-2.0/schemas/
+
+      install -Dm444 data/icons/xyz.timtimtim.Losange.svg -t $out/share/icons/hicolor/scalable/apps/
+      install -Dm444 data/xyz.timtimtim.Losange.desktop -t $out/share/applications/
+      install -Dm444 data/xyz.timtimtim.Losange.metainfo.xml -t $out/share/metainfo/
+
+      # The application fails if '-o' is passed without an argument (e.g. when opened using a launcher)
+      # therefore we match upstream's shell wrapper to handle empty URL cases.
+      substituteInPlace $out/share/applications/xyz.timtimtim.Losange.desktop \
+        --replace-fail "Exec=sh -c \"/usr/bin/losange -o '%u'\"" "Exec=sh -c \"losange -o '%u'\""
+    '';
+
+    # Node.js is required to run `server.js`
+    # Losange will automatically download the required version of `server.js` at runtime.
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --prefix PATH : "${lib.makeBinPath [ nodejs ]}"
+      )
+    '';
+
+    meta = {
+      mainProgram = "losange";
+      description = "Simple Stremio client for GNOME";
+      homepage = "https://github.com/tymmesyde/Losange";
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.linux;
+    };
+  }
+)


### PR DESCRIPTION
Hi! 👋

This PR adds a `flake.nix` to the repository to greatly improve the experience for users and contributors that use Nix/NixOS.

The PR includes:
- Reproducible development environment (`./nix/devShell.nix`): contributors can now instantly enter a ready-to-use development shell with all the necessary  dependencies by running  `nix develop` from the repo root.
- Direct installation using flake (`./nix/package.nix`): users can easily run or install the latest version directly from this repository without needing to wait for a Nixpkgs update. This is especially important for users that want to install a development version (latest commit) of Losange which won't be available in Nixpkgs as that only has stable releases. 

Let me know if you have any questions or want me to make any adjustments!